### PR TITLE
Force pymongo version minor than 4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3-slim-buster
 
-RUN pip install pymongo
+RUN pip install "pymongo<4.0"
 
 ENV MONGO_USER "admin"
 ENV MONGO_PASSWORD_PATH ".MONGO_PASSWORD"


### PR DESCRIPTION
Some pymongo methods used in this code don't exist anymore starting from pymongo v4.0 (For example `users.update()` on line 69). Forcing pymongo version less than 4.0 will make the script work again until someone will refresh the code with support for pymongo >= 4.0

See https://stackoverflow.com/questions/72177262/collection-object-is-not-callable-if-you-meant-to-call-the-update-method-on